### PR TITLE
修复 php7.4 php8 更新后报错 参数不能为null问题

### DIFF
--- a/src/filesystem/Driver.php
+++ b/src/filesystem/Driver.php
@@ -73,7 +73,7 @@ abstract class Driver
 
         $config = array_intersect_key($this->config, array_flip(['visibility', 'disable_asserts', 'url']));
 
-        return new Filesystem($adapter, count($config) > 0 ? $config : null);
+        return new Filesystem($adapter, count($config) > 0 ? $config : []);
     }
 
     /**


### PR DESCRIPTION
[0]Argument 2 passed to League\Flysystem\Filesystem::__construct() must be of the type array, null given, called in /wwwroot/vendor/topthink/think-filesystem/src/filesystem/Driver.php on line 58